### PR TITLE
Some fixes for 3ds Max 2021

### DIFF
--- a/scripts/kso_3dsmax.ini
+++ b/scripts/kso_3dsmax.ini
@@ -28,7 +28,6 @@ KSOMode:	*KSOMode*
 KSOPort:	*KSOPort*
 PyModPath:	*PyModPath*
 LogFile:	*LogFile*
-ElementsFolder:	*ElementsFolder*
 GammaApply:	*GammaApply*
 GammaIn:	*GammaIn*
 GammaOut: 	*GammaOut*
@@ -46,6 +45,3 @@ limitTime: *limitTime*
 limitNoise: *limitNoise*
 multiExr: *multiExr*
 showVfb: *showVfb*
-
-
-

--- a/scripts/kso_3dsmax.ini
+++ b/scripts/kso_3dsmax.ini
@@ -28,6 +28,7 @@ KSOMode:	*KSOMode*
 KSOPort:	*KSOPort*
 PyModPath:	*PyModPath*
 LogFile:	*LogFile*
+ElementsFolder:	*ElementsFolder*
 GammaApply:	*GammaApply*
 GammaIn:	*GammaIn*
 GammaOut: 	*GammaOut*
@@ -45,3 +46,6 @@ limitTime: *limitTime*
 limitNoise: *limitNoise*
 multiExr: *multiExr*
 showVfb: *showVfb*
+
+
+

--- a/scripts/kso_3dsmax_pymxs.py
+++ b/scripts/kso_3dsmax_pymxs.py
@@ -655,7 +655,7 @@ def applyRendererOptions_Vray(arg):
 
     if argValid(arg.RenderThreads):
         logMessageSET("VRay render threads  to " + str(arg.RenderThreads))
-        vray_settings.system_numThreads = arg.RenderThreads
+        vray_settings.system_numThreads = int(arg.RenderThreads)
     if argValid(arg.VRayMemLimit):
         logMessageSET("VRay mem limit to " + str(arg.VRayMemLimit))
         vray_settings.system_raycaster_memLimit = arg.VRayMemLimit

--- a/scripts/kso_3dsmax_pymxs.py
+++ b/scripts/kso_3dsmax_pymxs.py
@@ -1021,7 +1021,7 @@ def render_main():
     # So to prevent VRay message boxes to freeze the session, we will set VRay to silent mode here, before the scene is loaded.
     try:
         rt.setVRaySilentMode()
-        logMessage("VRay set to silent mode")
+        logMessageSET("VRay to Silent Mode")
     except:
         pass
 

--- a/scripts/kso_3dsmax_pymxs.py
+++ b/scripts/kso_3dsmax_pymxs.py
@@ -1032,8 +1032,8 @@ def render_main():
    
     
     logMessage("Gamma Settings: Enabled: {0} In: {1} Out: {2}".format((rt.iDisplayGamma.colorCorrectionMode == rt.name('gamma')),
-                                                                      rt.fileInGamma,
-                                                                      rt.fileOutGamma))
+                                                                      round(rt.fileInGamma, 5),
+                                                                      round(rt.fileOutGamma, 5)))
 
     if argValid(arg.StateSet):
         stateSet = str(arg.StateSet)

--- a/scripts/kso_3dsmax_pymxs.py
+++ b/scripts/kso_3dsmax_pymxs.py
@@ -445,7 +445,6 @@ def applyOutput_default(arg, frameNr, verbose):
                 logMessageSET("element %20s output to '%s'" % (elemName, fileout))
             fileout = os.path.normpath(fileout)
             filedir = os.path.dirname(fileout)
-            fileout = fileout.replace("\\", "\\\\")
             logMessageDebug("applyOutput_default -  " + fileout)
             rt.maxOps.GetCurRenderElementMgr().SetRenderElementFilename(elemNr, fileout)
 
@@ -539,7 +538,6 @@ def applyOutput_VRay(arg, frameNr, verbose):
 
         filedir = os.path.dirname(fileout)
         fileout = os.path.normpath(fileout)
-        fileout = fileout.replace("\\", "\\\\")
         vray_settings.output_splitfilename = fileout
         checkCreateFolder(filedir, verbose)
         if ((not rt.rendSaveFile)
@@ -551,7 +549,6 @@ def applyOutput_VRay(arg, frameNr, verbose):
         logMessageDebug("applyOutput_VRay - output_saveRawFile")
         fileout = arg.FName + arg.FExt
         fileout = os.path.normpath(fileout)
-        fileout = fileout.replace("\\", "\\\\")
         vray_settings.output_rawFileName = fileout
 
         mainFileName = arg.FName + str(frameNr).zfill(arg.FPadding) + arg.FExt
@@ -615,7 +612,6 @@ def applyOutput_VRay(arg, frameNr, verbose):
                 logMessageSET("element %20s output to '%s'" % (elemName, fileout))
             filedir = os.path.dirname(fileout)
             fileout = os.path.normpath(fileout)
-            fileout.replace("\\", "\\\\")
             checkCreateFolder(filedir, verbose)
             rt.maxOps.GetCurRenderElementMgr().SetRenderElementFilename(elemNr, fileout)
     return mainFileName
@@ -738,7 +734,6 @@ def applyRendererOptions_Vray(arg):
             vray_settings.gi_on = True
         fileout = arg.FName + arg.FExt
         fileout = os.path.normpath(fileout)
-        fileout = fileout.replace("\\", "\\\\")
         logMessageSET("VRay GI vrmap prepass to " + fileout)
         vray_settings.adv_irradmap_autoSaveFileName = fileout
         logMessageSET("VRay GI vrmap/animation prepass")

--- a/scripts/kso_3dsmax_pymxs.py
+++ b/scripts/kso_3dsmax_pymxs.py
@@ -658,7 +658,7 @@ def applyRendererOptions_Vray(arg):
         vray_settings.system_numThreads = int(arg.RenderThreads)
     if argValid(arg.VRayMemLimit):
         logMessageSET("VRay mem limit to " + str(arg.VRayMemLimit))
-        vray_settings.system_raycaster_memLimit = arg.VRayMemLimit
+        vray_settings.system_raycaster_memLimit = int(arg.VRayMemLimit)
     elif (argValid(arg.VRayMemLimitPercent) and argValid(arg.ClientTotalMemory)):
         memory = int(arg.ClientTotalMemory) * int(arg.VRayMemLimitPercent) // 100
         logMessageSET(
@@ -670,10 +670,10 @@ def applyRendererOptions_Vray(arg):
     if arg.vrayOverrideResolution:
         if argValid(arg.ResX):
             logMessageSET("width to " + str(arg.ResX))
-            vray_settings.output_width = arg.ResX
+            vray_settings.output_width = int(arg.ResX)
         if argValid(arg.ResY):
             logMessageSET("height to " + str(arg.ResY))
-            vray_settings.output_height = arg.ResY
+            vray_settings.output_height = int(arg.ResY)
 
     if (argValid(arg.limitNoise) or argValid(arg.limitTime)):
         samplerType = vray_settings.imageSampler_type_new
@@ -694,11 +694,11 @@ def applyRendererOptions_Vray(arg):
         arg.limitNoise = float(arg.limitNoise)
         arg.limitNoise = arg.limitNoise / 100.0
         logMessageSET("VRay progressive noise limit to " + str(arg.limitNoise) + " minutes.")
-        vray_settings.progressive_noise_threshold = arg.limitTime
+        vray_settings.progressive_noise_threshold = float(arg.limitNoise)
 
     if argValid(arg.limitTime):
         logMessageSET("VRay progressive time limit to {0} minutes".format(arg.limitTime))
-        vray_settings.progressive_max_render_time = arg.limitTime
+        vray_settings.progressive_max_render_time = float(arg.limitTime)
         noiseThreshold = vray_settings.progressive_noise_threshold
         if not argValid(arg.limitNoise):
             logMessage("VRay noiseThreshold setting: " + str(noiseThreshold))

--- a/scripts/kso_3dsmax_pymxs.py
+++ b/scripts/kso_3dsmax_pymxs.py
@@ -707,10 +707,6 @@ def applyRendererOptions_Vray(arg):
     arg.vraySeperateRenderChannels = vray_settings.output_splitgbuffer
     arg.vrayRawFile = vray_settings.output_saveRawFile
 
-    if arg.vrayFramebuffer:
-        if (not arg.vrayRawFile) and (not arg.vraySeperateRenderChannels):
-            arg.vrayFramebuffer = False
-            arg.renderChannels = False
     if not arg.vrayFramebuffer:
         arg.vraySeperateRenderChannels = False
         vray_settings.output_splitgbuffer = False
@@ -739,10 +735,10 @@ def applyRendererOptions_Vray(arg):
         logMessageSET("VRay GI vrmap/animation prepass")
         vray_settings.adv_irradmap_mode = 6
         logMessage("VRay GI irradiance mode: #" + str(vray_settings.adv_irradmap_mode))
-        logMessageSET("VRay Seperate Render Channels On")
-        vray_settings.output_splitgbuffer = False  # FIXME: LogMessage or command is inverted
-        logMessageSET("VRay Framebuffer Off")
-        vray_settings.output_on = True  # FIXME: LogMessage or command is inverted
+        logMessageSET("VRay Raw Off")
+        vray_settings.output_saveRawFile = False
+        logMessageSET("VRay Seperate Render Channels Off")
+        vray_settings.output_splitgbuffer = False
         logMessageSET("Main 3dsmax save file Off")
         rt.rendSaveFile = False
     else:

--- a/scripts/kso_3dsmax_pymxs.py
+++ b/scripts/kso_3dsmax_pymxs.py
@@ -1017,6 +1017,14 @@ def render_main():
             rt.fileOutGamma = part
  
  
+    # For an unknown reason, VRay is not automatically set to silent mode. (We believe it's becasue we use 3dsmaxbatch.exe instead of 3dsmaxcmd.exe)
+    # So to prevent VRay message boxes to freeze the session, we will set VRay to silent mode here, before the scene is loaded.
+    try:
+        rt.setVRaySilentMode()
+        logMessage("VRay set to silent mode")
+    except:
+        pass
+
     logMessage("Loading Scene '" + str(arg.SName) + "'...")
     if not rt.loadMaxFile(str(arg.SName), useFileUnits=True, quiet=True):
         logMessageError("Unable to open scene file")


### PR DESCRIPTION
I found some issues so I will keep adding to this PR but wanted to open it asap so we could have an discussion as well.

Found issues
* Setting VRay threads need to be an int. **FIXED**
* Bunch of other VRay settings needs to be converted to correct type. There was also a copy/pasta error that I fixed. **FIXED**
* UNC fileout paths comes out with three slashes in beginning causing rendering failure.
Problem seems to be excessive use of `fileout = fileout.replace("\\", "\\\\")` at several places in the code. **FIXED**
* Duplicate option in kso_3dsmax.ini throws an error in Python 3. **FIXED**
* VRay isn't automatically started in silent mode under 3dsmaxbatch.exe.
This causes rendering to halt if any VRay pop up is opened and waiting for a response. Overwriting the placeholder file is one of them causing VRay to always halt indefinitely. But other cases could be a pop up on scene open telling that this was created in an older version, etc.
The fix is to call setVRaySilentMode(). To fix the issue with popups on scene load, this need to be called before the scene is opened, which means it will be called even if the scene doesn't use VRay at all. **FIXED**