### PR TITLE
nuke submission: use tempfile instead of open

### DIFF
--- a/_submitplugins/rrSubmit_Nuke_5.py
+++ b/_submitplugins/rrSubmit_Nuke_5.py
@@ -169,10 +169,7 @@ class rrJob(object):
                 pass
             return False
 
-        if sys.version_info.major == 2:
-            xml.write(f)
-        else:
-            xml.write(f, encoding='unicode')
+        xml.write(f)
         f.close()
 
         return True


### PR DESCRIPTION
as described by @JenusL in issue #3, our Nuke submission relies on python 2 builtin function "open" in order to create its temp xml file.

the issue's discussion contain valid proposals to get a mixed py2/py3 plugin. The workaround proposed in this PR is to use _tempfile.NamedTemporaryFile_ instead, in order to leave most of the logic to python itself.

Possible cons.

_NamedTemporaryFile_ doesnt' accept an _encoding_ parameter in python 2, so we have to eithre leave that implicit, or use a different line according to the version